### PR TITLE
Add Distribution Group parameter

### DIFF
--- a/src/main/java/io/jenkins/plugins/appcenter/remote/AppCenterServiceFactory.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/remote/AppCenterServiceFactory.java
@@ -22,14 +22,16 @@ public class AppCenterServiceFactory implements Serializable {
     private final Secret apiToken;
     private final String ownerName;
     private final String appName;
+    private final String distributionGroup;
     private final String pathToApp;
     private final String baseUrl;
 
     public AppCenterServiceFactory(@Nonnull Secret apiToken, @Nonnull String ownerName, @Nonnull String appName,
-                                   @Nonnull String pathToApp, @Nullable URL baseUrl) {
+                                   @Nonnull String distributionGroup, @Nonnull String pathToApp, @Nullable URL baseUrl) {
         this.apiToken = apiToken;
         this.ownerName = ownerName;
         this.appName = appName;
+        this.distributionGroup = distributionGroup;
         this.pathToApp = pathToApp;
         this.baseUrl = baseUrl != null ? baseUrl.toString() : APPCENTER_BASE_URL;
     }
@@ -101,6 +103,10 @@ public class AppCenterServiceFactory implements Serializable {
 
     public String getAppName() {
         return appName;
+    }
+
+    public String getDistributionGroup() {
+        return distributionGroup;
     }
 
     public String getPathToApp() {

--- a/src/main/java/io/jenkins/plugins/appcenter/task/UploadTask.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/task/UploadTask.java
@@ -29,6 +29,7 @@ public final class UploadTask extends AppCenterTask {
     private final TaskListener taskListener;
     private final String ownerName;
     private final String appName;
+    private final String distributionGroup;
     private final FilePath pathToApp;
 
     public UploadTask(final FilePath filePath, final TaskListener taskListener, final AppCenterServiceFactory factory) {
@@ -37,6 +38,7 @@ public final class UploadTask extends AppCenterTask {
         this.taskListener = taskListener;
         this.ownerName = factory.getOwnerName();
         this.appName = factory.getAppName();
+        this.distributionGroup = factory.getDistributionGroup();
         this.pathToApp = filePath.child(factory.getPathToApp());
     }
 
@@ -115,7 +117,7 @@ public final class UploadTask extends AppCenterTask {
 
         final String releaseNotes = "";
         final boolean mandatoryUpdate = false;
-        final List<DestinationId> destinations = Collections.singletonList(new DestinationId("Collaborators", null));
+        final List<DestinationId> destinations = Collections.singletonList(new DestinationId(distributionGroup, null));
         final boolean notifyTesters = false;
         final ReleaseDetailsUpdateRequest releaseDetailsUpdateRequest = new ReleaseDetailsUpdateRequest(releaseNotes, mandatoryUpdate, destinations, null, notifyTesters);
 

--- a/src/main/java/io/jenkins/plugins/appcenter/validator/DistributionGroupValidator.java
+++ b/src/main/java/io/jenkins/plugins/appcenter/validator/DistributionGroupValidator.java
@@ -1,0 +1,14 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import javax.annotation.Nonnull;
+import java.util.function.Predicate;
+
+public final class DistributionGroupValidator extends Validator {
+
+    @Nonnull
+    @Override
+    protected Predicate<String> predicate() {
+        return value -> !value.trim().isEmpty();
+    }
+
+}

--- a/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
+++ b/src/main/resources/io/jenkins/plugins/appcenter/Messages.properties
@@ -1,9 +1,11 @@
 AppCenterRecorder.DescriptorImpl.errors.missingApiToken=Please specify an AppCenter API Token
-AppCenterRecorder.DescriptorImpl.errors.invalidApiToken=API Token canot contain whitespace
+AppCenterRecorder.DescriptorImpl.errors.invalidApiToken=API Token can't contain whitespace
 AppCenterRecorder.DescriptorImpl.errors.missingOwnerName=Please specify an AppCenter Owner Name
 AppCenterRecorder.DescriptorImpl.errors.invalidOwnerName=Username can only contain letters, numbers, dashes, underscores, or full stops
 AppCenterRecorder.DescriptorImpl.errors.missingAppName=Please specify an AppCenter App Name
 AppCenterRecorder.DescriptorImpl.errors.invalidAppName=App name cannot contain whitespace
+AppCenterRecorder.DescriptorImpl.errors.missingDistributionGroup=Please specify a Distribution Group
+AppCenterRecorder.DescriptorImpl.errors.invalidDistributionGroup=Distribution Group can only contain letters, numbers, dashes, underscores, or spaces
 AppCenterRecorder.DescriptorImpl.errors.missingPathToApp=Please specify a path to the app you wish to upload
 AppCenterRecorder.DescriptorImpl.errors.invalidPathToApp=Path must be relative
 AppCenterRecorder.DescriptorImpl.DisplayName=Upload app to AppCenter

--- a/src/test/java/io/jenkins/plugins/appcenter/FreestyleTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/FreestyleTest.java
@@ -52,7 +52,7 @@ public class FreestyleTest {
         // Given
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
-        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "path/to/app.apk");
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "Collaborators", "path/to/app.apk");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").url());
         freeStyleProject.getPublishersList().add(appCenterRecorder);
 
@@ -68,7 +68,7 @@ public class FreestyleTest {
         // Given
         mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "path/to/app.apk");
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "Collaborators", "path/to/app.apk");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").url());
         freeStyleProject.getPublishersList().add(appCenterRecorder);
 
@@ -91,7 +91,7 @@ public class FreestyleTest {
                 "}"));
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
-        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "path/to/app.apk");
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "Collaborators", "path/to/app.apk");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").url());
         freeStyleProject.getPublishersList().add(appCenterRecorder);
 
@@ -119,7 +119,7 @@ public class FreestyleTest {
         mockWebServer.enqueue(new MockResponse().setResponseCode(200));
         mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "path/to/app.apk");
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "Collaborators", "path/to/app.apk");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").url());
         freeStyleProject.getPublishersList().add(appCenterRecorder);
 
@@ -153,7 +153,7 @@ public class FreestyleTest {
                 "}"));
         mockWebServer.enqueue(new MockResponse().setResponseCode(400));
 
-        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "path/to/app.apk");
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "Collaborators", "path/to/app.apk");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").url());
         freeStyleProject.getPublishersList().add(appCenterRecorder);
 
@@ -191,7 +191,7 @@ public class FreestyleTest {
                 "  \"release_notes\": \"string\"\n" +
                 "}"));
 
-        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "path/to/app.apk");
+        final AppCenterRecorder appCenterRecorder = new AppCenterRecorder("token", "owner_name", "app_name", "Collaborators", "path/to/app.apk");
         appCenterRecorder.setBaseUrl(mockWebServer.url("/").url());
         freeStyleProject.getPublishersList().add(appCenterRecorder);
 

--- a/src/test/java/io/jenkins/plugins/appcenter/validator/DistributionGroupValidatorTest.java
+++ b/src/test/java/io/jenkins/plugins/appcenter/validator/DistributionGroupValidatorTest.java
@@ -1,0 +1,52 @@
+package io.jenkins.plugins.appcenter.validator;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class DistributionGroupValidatorTest {
+
+    private Validator validator;
+
+    @Before
+    public void setUp() {
+        validator = new DistributionGroupValidator();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_DistributionGroupContainsAlphanumericCharacters() {
+        // Given
+        final String value = "Collaborators";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnTrue_When_DistributionGroupContainsComplexCharacters() {
+        // Given
+        final String value = "Internal test group 5 漢字 !";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    public void should_ReturnFalse_When_DistributionGroupIsEmpty() {
+        // Given
+        final String value = "  ";
+
+        // When
+        final boolean result = validator.isValid(value);
+
+        // Then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
This requires the distribution group to be specified when publishing a build. Previously it was hardcoded to the `Collaborators` group.

I've added a basic unit test even though I don't think there are any real restrictions on the content of the identifier string.

I'm not actually familiar with Jenkins plugins so this is just my guess at what needs to be done to add this parameter. Please let me know if anything is missing.